### PR TITLE
support fetching xz tarballs

### DIFF
--- a/bin/nvh
+++ b/bin/nvh
@@ -676,6 +676,8 @@ function install() {
     fi
   fi
 
+  [[ "${NVH_USE_XZ}" = "true" ]] && can_use_xz || NVH_USE_XZ="false"
+
   echo
   install_log "installing" "${g_mirror_folder_name}/${resolved_version}"
 

--- a/bin/nvh
+++ b/bin/nvh
@@ -309,6 +309,7 @@ Options:
   --insecure          Turn off certificate checking for https requests (may be needed from behind a proxy server)
   -p, --preserve      Preserve npm and npx during install of node
   --use-xz            Download xz-compressed tarballs, if available and extractable by tar, during install of node (this is the default)
+  --force-use-xz      Download xz-compressed tarballs. May fail if xz tarball is not available and extractable
   --no-use-xz         Download gzip-compressed tarballs, rather than xz-compressed ones, during install of node
   -V, --version       Output version of nvh
 
@@ -1200,6 +1201,7 @@ function main() {
       -p|--preserve) NVH_PRESERVE_NPM="true" ;;
       --no-preserve) NVH_PRESERVE_NPM="" ;;
       --use-xz) NVH_USE_XZ="true"; g_xz_force_enabled="false" ;;
+      --force-use-xz) NVH_USE_XZ="true"; g_xz_force_enabled="true" ;;
       --no-use-xz) NVH_USE_XZ="false" ;;
       -V|--version) echo "${VERSION}"; exit ;;
       -*) abort "unrecognised option '$1'"; exit 1 ;;

--- a/bin/nvh
+++ b/bin/nvh
@@ -667,6 +667,14 @@ function install() {
   echo
   install_log "installing" "${g_mirror_folder_name}/${resolved_version}"
 
+  if [[ "${NVH_USE_XZ}" = "true" ]]; then
+    local resolved_major_version
+    resolved_major_version="$(echo ${resolved_version#v} | cut -d '.' -f '1')"
+    if [[ "${resolved_major_version}" -lt 4 ]]; then
+      NVH_USE_XZ="false"
+    fi
+  fi
+
   local url="$(tarball_url "${resolved_version}")"
   is_ok "${url}" || abort "download preflight failed for '$resolved_version' (${url})"
 

--- a/bin/nvh
+++ b/bin/nvh
@@ -22,12 +22,16 @@ NVH_NODE_DOWNLOAD_MIRROR=${NVH_NODE_DOWNLOAD_MIRROR:-https://nodejs.org/download
 NVH_NODE_DOWNLOAD_MIRROR=${NVH_NODE_DOWNLOAD_MIRROR%/}
 readonly NVH_NODE_DOWNLOAD_MIRROR
 
-# Enabled by default. User may set NVH_USE_XZ to 0 to disable.
-# Normalise to true/false.
+# Using xz instead of gzip is enabled by default, if xz compatibility checks pass.
+# User may set NVH_USE_XZ to 0 to disable, or set to anything else to force-enable.
 # May be overridden by command line flags.
 
+g_xz_force_enabled="false"
 if [[ "${NVH_USE_XZ}" = "0" ]]; then
   NVH_USE_XZ="false"
+elif [[ -n "${NVH_USE_XZ+defined}" ]]; then
+  NVH_USE_XZ="true"
+  g_xz_force_enabled="true"
 else
   NVH_USE_XZ="true"
 fi
@@ -686,12 +690,14 @@ function install() {
     fi
   fi
 
-  [[ "${NVH_USE_XZ}" = "true" ]] && can_use_xz || NVH_USE_XZ="false"
+  if [[ "${NVH_USE_XZ}" = true ]] && [[ "S{g_xz_force_enabled}" = "false" ]]; then
+    can_use_xz || NVH_USE_XZ="false"
+  fi
 
   echo
   install_log "installing" "${g_mirror_folder_name}/${resolved_version}"
 
-  if [[ "${NVH_USE_XZ}" = "true" ]]; then
+  if [[ "${NVH_USE_XZ}" = "true" ]] && [[ "${g_xz_force_enabled}" = "false" ]]; then
     local resolved_major_version
     resolved_major_version="$(echo ${resolved_version#v} | cut -d '.' -f '1')"
     if [[ "${resolved_major_version}" -lt 4 ]]; then
@@ -1193,7 +1199,7 @@ function main() {
       --insecure) set_insecure ;;
       -p|--preserve) NVH_PRESERVE_NPM="true" ;;
       --no-preserve) NVH_PRESERVE_NPM="" ;;
-      --use-xz) NVH_USE_XZ="true" ;;
+      --use-xz) NVH_USE_XZ="true"; g_xz_force_enabled="false" ;;
       --no-use-xz) NVH_USE_XZ="false" ;;
       -V|--version) echo "${VERSION}"; exit ;;
       -*) abort "unrecognised option '$1'"; exit 1 ;;

--- a/bin/nvh
+++ b/bin/nvh
@@ -568,7 +568,11 @@ function display_compatible_file_field {
 
 function tarball_url() {
   local version="$1"
-  echo "${g_mirror_url}/${version}/node-${version}-$(display_tarball_platform).tar.gz"
+
+  local ext="gz"
+  if [[ "${NVH_USE_XZ}" = "true" ]]; then local ext="xz"; fi
+
+  echo "${g_mirror_url}/${version}/node-${version}-$(display_tarball_platform).tar.${ext}"
 }
 
 #
@@ -664,6 +668,9 @@ function install() {
   local url="$(tarball_url "${resolved_version}")"
   is_ok "${url}" || abort "download preflight failed for '$resolved_version' (${url})"
 
+  local tarflags="-zx"
+  if [[ "${NVH_USE_XZ}" = "true" ]]; then local tarflags="-Jx"; fi
+
   install_log "mkdir" "${dir}"
   mkdir -p "${dir}" || abort "sudo required (or change ownership, or define NVH_PREFIX)"
   touch "${dir}/nvh.lock"
@@ -671,7 +678,7 @@ function install() {
   cd "${dir}" || abort "Failed to cd to directory"
 
   install_log "fetch" "${url}"
-  do_get "${url}" | tar -zx --strip-components=1
+  do_get "${url}" | tar "${tarflags}" --strip-components=1
   [[ "${GET_OPTIONS_SHOW_PROGRESS}" = "true" ]] && erase_line
   rm -f "${dir}/nvh.lock"
 

--- a/bin/nvh
+++ b/bin/nvh
@@ -294,6 +294,8 @@ Options:
   -h, --help          Display help information
   --insecure          Turn off certificate checking for https requests (may be needed from behind a proxy server)
   -p, --preserve      Preserve npm and npx during install of node
+  --use-xz            Download xz-compressed tarballs, if available and extractable by tar, during install of node (this is the default)
+  --no-use-xz         Download gzip-compressed tarballs, rather than xz-compressed ones, during install of node
   -V, --version       Output version of nvh
 
 Aliases:
@@ -1159,6 +1161,8 @@ function main() {
       --insecure) set_insecure ;;
       -p|--preserve) NVH_PRESERVE_NPM="true" ;;
       --no-preserve) NVH_PRESERVE_NPM="" ;;
+      --use-xz) NVH_USE_XZ="true" ;;
+      --no-use-xz) NVH_USE_XZ="false" ;;
       -V|--version) echo "${VERSION}"; exit ;;
       -*) abort "unrecognised option '$1'"; exit 1 ;;
       exec) unprocessed_args=("$@"); break ;;

--- a/bin/nvh
+++ b/bin/nvh
@@ -518,6 +518,18 @@ function is_ok() {
 }
 
 #
+# Synopsis: can_use_xz
+#
+
+function can_use_xz() {
+  # nvh uses xz on Linux and macOS at this time, if the system supports it
+  if ! ([[ "$(uname -s)" = "Linux" ]] && command -v xz &> /dev/null) \
+  && ! ([[ "$(uname -s)" = "Darwin" ]] && [[ "$(sw_vers -productVersion | cut -d '.' -f 2)" -gt "8" ]]); then
+    return 1
+  fi
+}
+
+#
 # Synopsis: display_tarball_platform
 #
 

--- a/bin/nvh
+++ b/bin/nvh
@@ -22,6 +22,16 @@ NVH_NODE_DOWNLOAD_MIRROR=${NVH_NODE_DOWNLOAD_MIRROR:-https://nodejs.org/download
 NVH_NODE_DOWNLOAD_MIRROR=${NVH_NODE_DOWNLOAD_MIRROR%/}
 readonly NVH_NODE_DOWNLOAD_MIRROR
 
+# Enabled by default. User may set NVH_USE_XZ to 0 to disable.
+# Normalise to true/false.
+# May be overridden by command line flags.
+
+if [[ "${NVH_USE_XZ}" = "0" ]]; then
+  NVH_USE_XZ="false"
+else
+  NVH_USE_XZ="true"
+fi
+
 # NVH_PRESERVE_NPM tested with -z -n
 # made readonly after CLI option parsing
 


### PR DESCRIPTION
Closes #8

This is the xz feature. As I see it...

Technical goals include:
- Basic ability to download xz tarballs
- Ability to fall back to gzip if necessary

Preferences already identified:
- xz should be able to be on by default, without this change causing problems for existing end-users

Nice to have:
- Reasonable way to configure this by environment variable
- Reasonable way to configure this by command-line flags

Totally optional:
- Backward compatibility for environment variable with the prior implementation at `tj/n` (https://github.com/tj/n/pull/571)
  - This is totally optional, since implementation can be tweaked upon porting to `n`, or the old `n` environment variable could be tweaked/deprecated, etc.

I believe this PR as initially posted meets those goals, but could perhaps be refined. (Although I note it is quite possible to bikeshed the minor things, so would prefer to settle on something soonish, rather than extend discussion too indefinitely...)

meta: commits are very spaced out/tiny, to aid in some rebasing and tweaks I have been doing. Can consolidate a bit if/as desired.