### PR TITLE
Add some node support aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- markdownlint-disable MD024 -->
 
+## [9.4.0] (2020-04-27)
+
+### Added
+
+- support for some node support aliases, such as `lts_latest`
+
 ## [9.3.0] (2020-04-12)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ There is support for release streams:
 
 - `argon`, `boron`, `carbon`: codenames for LTS release streams
 
+These node support aliases may be used, although for now simply resolve to the latest matching version:
+
+- `active`, `lts_active`, `lts_latest`, `lts`, `current`
+
 The last form is for specifying [other releases](https://nodejs.org/download) available using the name of the remote download folder optionally followed by the complete or incomplete version.
 
 - `chakracore-release/latest`

--- a/bin/nvh
+++ b/bin/nvh
@@ -261,6 +261,31 @@ function is_exact_numeric_version() {
 }
 
 #
+# Synopsis: is_node_support_version version
+# Reference: https://github.com/nodejs/package-maintenance/issues/236#issue-474783582
+#
+
+function is_node_support_version() {
+  [[ "$1" =~ ^(active|lts_active|lts_latest|lts|current)$ ]]
+}
+
+#
+# Synopsis: display_latest_node_support_alias version
+# Map aliases onto existing n aliases, current and lts
+#
+
+function display_latest_node_support_alias() {
+  case "$1" in
+    "active") printf "current" ;;
+    "lts_active") printf "lts" ;;
+    "lts_latest") printf "lts" ;;
+    "lts") printf "lts" ;;
+    "current") printf "current" ;;
+    *) printf "unexpected-version"
+  esac
+}
+
+#
 # Functions used when showing versions installed
 #
 
@@ -345,6 +370,7 @@ Versions:
     latest, current   Newest official release
     auto              Read version from .nvh-node-version
     boron, carbon     Codenames for release streams
+    lts_latest        node support aliases
     and nightly, chakracore-release/latest, rc/10 et al
 
 Examples:
@@ -941,6 +967,10 @@ function display_remote_versions() {
   update_mirror_settings_for_version "${version}"
   local match='.'
   local match_count="${NVH_MAX_REMOTE_MATCHES}"
+  if is_node_support_version "${version}"; then
+    version="$(display_latest_node_support_alias "${version}")"
+    match_count=1
+  fi
   if [[ -z "${version}" ]]; then
     match='.'
   elif [[ "${version}" = "lts" ]]; then
@@ -1304,7 +1334,7 @@ function main() {
       run) shift; run_with_version "$@" ;;
       uninstall) uninstall_installed ;;
       which) shift; display_bin_path_for_version "$1" ;;
-      NVH_MOCK_DISPLAY_LATEST_RESOLVED_VERSION) shift; display_latest_resolved_version "$1"; exit ;;
+      NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION) shift; display_latest_resolved_version "$1"; exit ;;
       *) abort "unrecognised command '$1' (perhaps you want 'nvh install $1'?)" ;;
     esac
   fi

--- a/test/tests/version-resolve.bats
+++ b/test/tests/version-resolve.bats
@@ -5,6 +5,8 @@
 load shared-functions
 
 
+# auto
+
 function setup() {
   unset_nvh_env
   tmpdir="${TMPDIR:-/tmp}"
@@ -15,14 +17,14 @@ function setup() {
 @test "auto, missing file" {
   cd "${MY_DIR}"
   rm -f .nvh-node-version
-  run nvh NVH_MOCK_DISPLAY_LATEST_RESOLVED_VERSION auto
+  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
   [ "$status" -ne 0 ]
 }
 
 @test "auto, no eol" {
   cd "${MY_DIR}"
   printf "101.0.1" > .nvh-node-version
-  run nvh NVH_MOCK_DISPLAY_LATEST_RESOLVED_VERSION auto
+  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
   [ "$status" -eq 0 ]
   [ "$output" = "v101.0.1" ]
 }
@@ -30,7 +32,7 @@ function setup() {
 @test "auto, unix eol" {
   cd "${MY_DIR}"
   printf "101.0.2\n" > .nvh-node-version
-  run nvh NVH_MOCK_DISPLAY_LATEST_RESOLVED_VERSION auto
+  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
   [ "$status" -eq 0 ]
   [ "$output" = "v101.0.2" ]
 }
@@ -38,7 +40,7 @@ function setup() {
 @test "auto, Windows eol" {
   cd "${MY_DIR}"
   printf "101.0.3\r\n" > .nvh-node-version
-  run nvh NVH_MOCK_DISPLAY_LATEST_RESOLVED_VERSION auto
+  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
   [ "$status" -eq 0 ]
   [ "$output" = "v101.0.3" ]
 }
@@ -46,7 +48,7 @@ function setup() {
 @test "auto, leading v" {
   cd "${MY_DIR}"
   printf "v101.0.4\n" > .nvh-node-version
-  run nvh NVH_MOCK_DISPLAY_LATEST_RESOLVED_VERSION auto
+  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
   [ "$status" -eq 0 ]
   [ "$output" = "v101.0.4" ]
 }
@@ -54,7 +56,7 @@ function setup() {
 @test "auto, first line only" {
   cd "${MY_DIR}"
   printf "101.0.5\nmore text\n" > .nvh-node-version
-  run nvh NVH_MOCK_DISPLAY_LATEST_RESOLVED_VERSION auto
+  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
   [ "$status" -eq 0 ]
   [ "$output" = "v101.0.5" ]
 }
@@ -63,7 +65,44 @@ function setup() {
   # Check normal resolving, which is allowed but not required for MVP .nvh-node-version
   cd "${MY_DIR}"
   printf "4.9\n" > .nvh-node-version
-  run nvh NVH_MOCK_DISPLAY_LATEST_RESOLVED_VERSION auto
+  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
   [ "$status" -eq 0 ]
   [ "$output" = "v4.9.1" ]
+}
+
+# node support aliases
+
+@test "display_latest_resolved_version active" {
+  local TARGET_VERSION="$(display_remote_version latest)"
+  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION active
+  [ "$status" -eq 0 ]
+  [ "$output" = "${TARGET_VERSION}" ]
+}
+
+@test "display_latest_resolved_version lts_active" {
+  local TARGET_VERSION="$(display_remote_version lts)"
+  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION lts_active
+  [ "$status" -eq 0 ]
+  [ "$output" = "${TARGET_VERSION}" ]
+}
+
+@test "display_latest_resolved_version lts_latest" {
+  local TARGET_VERSION="$(display_remote_version lts)"
+  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION lts_latest
+  [ "$status" -eq 0 ]
+  [ "$output" = "${TARGET_VERSION}" ]
+}
+
+@test "display_latest_resolved_version lts" {
+  local TARGET_VERSION="$(display_remote_version lts)"
+  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION lts
+  [ "$status" -eq 0 ]
+  [ "$output" = "${TARGET_VERSION}" ]
+}
+
+@test "display_latest_resolved_version current" {
+  local TARGET_VERSION="$(display_remote_version latest)"
+  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION current
+  [ "$status" -eq 0 ]
+  [ "$output" = "${TARGET_VERSION}" ]
 }


### PR DESCRIPTION
Node is adopting some aliases to refer to useful combinations of release streams:
- https://github.com/nodejs/package-maintenance/blob/master/docs/drafts/PACKAGE-SUPPORT.md#node-name-space
- https://github.com/nodejs/package-maintenance/issues/236#issue-474783582

At this point the information about what lines are active or still supported is not available in `index.tab`, so for this PR the aliases simply revolve to either the latest lts node version of the current node version. In the future `nvh ls-remote` could display multiple versions where appropriate.

- node support alias => nvh existing alias
- `lts` => `lts`
- `lts_latest` => `lts`
- `active` => `current`
- `lts_active` => `lts`
- `current` => `current`

See also more detail in: https://github.com/tj/n/issues/617