### PR TITLE
bats updates

### DIFF
--- a/docs/tests.md
+++ b/docs/tests.md
@@ -27,13 +27,13 @@ Run all the tests on a single system:
 
     cd test
     npx bats tests
-    docker-compose run ubuntu-curl bats /mnt/tests
+    docker-compose run ubuntu-curl bats /mnt/test/tests
 
 Run single test on a single system:
 
     cd test
     npx bats tests/lsr.bats
-    docker-compose run ubuntu-curl bats /mnt/tests/lsr.bats
+    docker-compose run ubuntu-curl bats /mnt/test/tests/lsr.bats
 
 Run a single command on more containers:
 
@@ -59,7 +59,7 @@ The containers each have:
 Using `docker-compose` adds:
 
 * specified `nvh` script mounted to `/usr/local/bin/nvh`
-* `test/tests` mounted to `/mnt/tests`
+* `test/tests` mounted to `/mnt/test/tests`
 * `node_modules/bats` provides `/usr/local/bin/bats` et al
 * curl and wget startup files to suppress certificate checking, to allow proxy usage
 
@@ -69,4 +69,4 @@ So for example:
     docker-compose run ubuntu-curl
       # in container
       nvh --version
-      bats /mnt/tests
+      bats /mnt/test/tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,19 @@
   "requires": true,
   "dependencies": {
     "bats": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/bats/-/bats-1.1.0.tgz",
-      "integrity": "sha512-1pA29OhDByrUtAXX+nmqZxgRgx2y8PvuZzbLJVjd2dpEDVDvz0MjcBMdmIPNq5lC+tG53G+RbeRsbIlv3vw7tg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bats/-/bats-1.2.1.tgz",
+      "integrity": "sha512-2fcPDRQa/Kvh6j1IcCqsHpT5b9ObMzRzw6abC7Bg298PX8Qdh9VRkvO2WJUEhdyfjq2rLBCOAWdcv0tS4+xTUA==",
+      "dev": true
+    },
+    "bats-assert": {
+      "version": "github:bats-core/bats-assert#0a8dd57e2cc6d4cc064b1ed6b4e79b9f7fee096f",
+      "from": "github:bats-core/bats-assert",
+      "dev": true
+    },
+    "bats-support": {
+      "version": "github:bats-core/bats-support#d140a65044b2d6810381935ae7f0c94c7023c8c3",
+      "from": "github:bats-core/bats-support",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "bats": "^1.1.0"
+    "bats": "^1.2.1",
+    "bats-assert": "github:bats-core/bats-assert",
+    "bats-support": "github:bats-core/bats-support"
   }
 }

--- a/test/bin/proxy-build
+++ b/test/bin/proxy-build
@@ -36,7 +36,7 @@ https_proxy="$(hostname):8080"
 export https_proxy
 
 # linux. Do wget first to get uncompressed index.tab into cache to works with both curl and wget
-docker-compose run ubuntu-wget /mnt/tests/install-reference-versions.bash
+docker-compose run ubuntu-wget /mnt/test/tests/install-reference-versions.bash
 # native
 tests/install-reference-versions.bash
 

--- a/test/bin/run-all-tests
+++ b/test/bin/run-all-tests
@@ -6,7 +6,7 @@ services=( ubuntu-curl ubuntu-wget )
 cd "$(dirname "${BIN_DIRECTORY}")" || exit 2
 for service in "${services[@]}" ; do
   echo "${service}"
-  docker-compose run --rm "${service}" "bats" "/mnt/tests"
+  docker-compose run --rm "${service}" "bats" "/mnt/test/tests"
   echo ""
 done
 

--- a/test/docker-base.yml
+++ b/test/docker-base.yml
@@ -6,10 +6,14 @@ services:
       # make locally installed  bats available in container (based on bats/install.sh)
       - ../node_modules/bats/bin/bats:/usr/local/bin/bats
       - ../node_modules/bats/libexec/bats-core:/usr/local/libexec/bats-core
+      - ../node_modules/bats/lib/bats-core:/usr/local/lib/bats-core
       - ../node_modules/bats/man/bats.1:/usr/local/share/man/man1"
       - ../node_modules/bats/man/bats.7:/usr/local/share/man/man7"
       # the bats tests
-      - ./tests:/mnt/tests
+      - ./tests:/mnt/test/tests
+      # bats extra libraries, into similar relative location
+      - ../node_modules/bats-support:/mnt/node_modules/bats-support
+      - ../node_modules/bats-assert:/mnt/node_modules/bats-assert
       # nvh
       - ../bin/nvh:/usr/local/bin/nvh
       # override settings to allow insecure connection in case using proxy

--- a/test/tests/cache.bats
+++ b/test/tests/cache.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 load shared-functions
-
+load '../../node_modules/bats-support/load'
+load '../../node_modules/bats-assert/load'
 
 function setup() {
   unset_nvh_env
@@ -23,12 +24,10 @@ function teardown() {
 # nvh cache ls
 
 @test "nvh cache ls # albeit cache ls is undocumented" {
-  run nvh cache ls
-  [ "${status}" -eq "0" ]
-  [ "${lines[0]}" = "nightly/${NIGHTLY_VERSION}" ]
-  [ "${lines[1]}" = "node/${ARGON_VERSION}" ]
-  [ "${lines[2]}" = "node/${LTS_VERSION}" ]
-  [ "${lines[3]}" = "" ]
+  output=$(nvh cache ls)
+  assert_equal "${output}" "nightly/${NIGHTLY_VERSION}
+node/${ARGON_VERSION}
+node/${LTS_VERSION}"
 }
 
 
@@ -38,10 +37,8 @@ function teardown() {
 @test "nvh rm lts v4.9.1" {
   nvh rm lts v4.9.1
 
-  run nvh cache ls
-  [ "${status}" -eq "0" ]
-  [ "${lines[0]}" = "nightly/${NIGHTLY_VERSION}" ]
-  [ "${lines[1]}" = "" ]
+  output=$(nvh cache ls)
+  assert_equal "${output}" "nightly/${NIGHTLY_VERSION}"
 }
 
 
@@ -50,11 +47,9 @@ function teardown() {
 @test "nvh remove nightly/${NIGHTLY_VERSION}" {
   nvh remove "nightly/${NIGHTLY_VERSION}"
 
-  run nvh cache ls
-  [ "${status}" -eq "0" ]
-  [ "${lines[0]}" = "node/${ARGON_VERSION}" ]
-  [ "${lines[1]}" = "node/${LTS_VERSION}" ]
-  [ "${lines[2]}" = "" ]
+  output=$(nvh cache ls)
+  assert_equal "${output}" "node/${ARGON_VERSION}
+node/${LTS_VERSION}"
 }
 
 
@@ -63,11 +58,9 @@ function teardown() {
 @test "nvh cache rm 4 # albeit cache rm is undocumented" {
   nvh cache rm 4
 
-  run nvh cache ls
-  [ "${status}" -eq "0" ]
-  [ "${lines[0]}" = "nightly/${NIGHTLY_VERSION}" ]
-  [ "${lines[1]}" = "node/${LTS_VERSION}" ]
-  [ "${lines[2]}" = "" ]
+  output=$(nvh cache ls)
+  assert_equal "${output}" "nightly/${NIGHTLY_VERSION}
+node/${LTS_VERSION}"
 }
 
 
@@ -76,9 +69,8 @@ function teardown() {
 @test "nvh cache clear" {
   nvh cache clear
 
-  run nvh cache ls
-  [ "${status}" -eq "0" ]
-  [ "$output" = "" ]
+  output=$(nvh cache ls)
+  assert_equal "${output}" ""
 }
 
 
@@ -90,8 +82,6 @@ function teardown() {
   nvh install lts
   nvh cache prune
 
-  run nvh cache ls
-  [ "${status}" -eq "0" ]
-  [ "${lines[0]}" = "node/${LTS_VERSION}" ]
-  [ "${lines[1]}" = "" ]
+  output=$(nvh cache ls)
+  assert_equal "${output}" "node/${LTS_VERSION}"
 }

--- a/test/tests/cache.bats
+++ b/test/tests/cache.bats
@@ -24,7 +24,7 @@ function teardown() {
 # nvh cache ls
 
 @test "nvh cache ls # albeit cache ls is undocumented" {
-  output=$(nvh cache ls)
+  local output=$(nvh cache ls)
   assert_equal "${output}" "nightly/${NIGHTLY_VERSION}
 node/${ARGON_VERSION}
 node/${LTS_VERSION}"
@@ -37,7 +37,7 @@ node/${LTS_VERSION}"
 @test "nvh rm lts v4.9.1" {
   nvh rm lts v4.9.1
 
-  output=$(nvh cache ls)
+  local output=$(nvh cache ls)
   assert_equal "${output}" "nightly/${NIGHTLY_VERSION}"
 }
 
@@ -47,7 +47,7 @@ node/${LTS_VERSION}"
 @test "nvh remove nightly/${NIGHTLY_VERSION}" {
   nvh remove "nightly/${NIGHTLY_VERSION}"
 
-  output=$(nvh cache ls)
+  local output=$(nvh cache ls)
   assert_equal "${output}" "node/${ARGON_VERSION}
 node/${LTS_VERSION}"
 }
@@ -58,7 +58,7 @@ node/${LTS_VERSION}"
 @test "nvh cache rm 4 # albeit cache rm is undocumented" {
   nvh cache rm 4
 
-  output=$(nvh cache ls)
+  local output=$(nvh cache ls)
   assert_equal "${output}" "nightly/${NIGHTLY_VERSION}
 node/${LTS_VERSION}"
 }
@@ -69,7 +69,7 @@ node/${LTS_VERSION}"
 @test "nvh cache clear" {
   nvh cache clear
 
-  output=$(nvh cache ls)
+  local output=$(nvh cache ls)
   assert_equal "${output}" ""
 }
 
@@ -82,6 +82,6 @@ node/${LTS_VERSION}"
   nvh install lts
   nvh cache prune
 
-  output=$(nvh cache ls)
+  local output=$(nvh cache ls)
   assert_equal "${output}" "node/${LTS_VERSION}"
 }

--- a/test/tests/ls.bats
+++ b/test/tests/ls.bats
@@ -1,6 +1,8 @@
 #!/usr/bin/env bats
 
 load shared-functions
+load '../../node_modules/bats-support/load'
+load '../../node_modules/bats-assert/load'
 
 function setup() {
   unset_nvh_env
@@ -17,11 +19,9 @@ function teardown() {
   mkdir -p "${NVH_PREFIX}/nvh/versions/node/v4.9.1"
   mkdir -p "${NVH_PREFIX}/nvh/versions/node/v10.15.0"
 
-  run nvh ls
-  [ "$status" -eq 0 ]
-  [ "${lines[0]}" = "node/v4.9.1" ]
-  [ "${lines[1]}" = "node/v10.15.0" ]
-  [ "${lines[2]}" = "" ]
+  local output=$(nvh ls)
+  assert_equal "${output}" "node/v4.9.1
+node/v10.15.0"
 }
 
 
@@ -31,10 +31,8 @@ function teardown() {
   mkdir -p "${NVH_PREFIX}/nvh/versions/nightly/${NIGHTLY_VERSION}"
   mkdir -p "${NVH_PREFIX}/nvh/versions/node/v10.15.0"
 
-  run nvh list
-  [ "$status" -eq 0 ]
-  [ "${lines[0]}" = "nightly/${NIGHTLY_VERSION}" ]
-  [ "${lines[1]}" = "node/v10.15.0" ]
-  [ "${lines[2]}" = "" ]
+  local output=$(nvh list)
+  assert_equal "${output}" "nightly/${NIGHTLY_VERSION}
+node/v10.15.0"
 }
 

--- a/test/tests/lsr.bats
+++ b/test/tests/lsr.bats
@@ -1,6 +1,8 @@
 #!/usr/bin/env bats
 
 load shared-functions
+load '../../node_modules/bats-support/load'
+load '../../node_modules/bats-assert/load'
 
 
 function setup() {
@@ -11,140 +13,118 @@ function setup() {
 # labels
 
 @test "nvh lsr lts" {
-  run nvh lsr lts
-  [ "${status}" -eq "0" ]
-  [ "${output}" = "$(display_remote_version lts)" ]
+  local output=$(nvh lsr lts)
+  assert_equal "${output}" "$(display_remote_version lts)"
 }
 
 @test "nvh ls-remote latest" {
-  run nvh ls-remote latest
-  [ "${status}" -eq "0" ]
-  [ "${output}" = "$(display_remote_version latest)" ]
+  local output=$(nvh ls-remote latest)
+  assert_equal "${output}" "$(display_remote_version latest)"
 }
 
 @test "nvh list-remote current" {
-  run nvh list-remote current
-  [ "${status}" -eq "0" ]
-  [ "${output}" = "$(display_remote_version latest)" ]
+  local output=$(nvh list-remote current)
+  assert_equal "${output}" "$(display_remote_version latest)"
 }
 
 
 # codenames
 
 @test "n=1 nvh lsr argon" {
-  NVH_MAX_REMOTE_MATCHES=1 run nvh lsr argon
-  [ "${status}" -eq "0" ]
-  [ "${output}" = "v4.9.1" ]
+  local output=$(NVH_MAX_REMOTE_MATCHES=1 nvh lsr argon)
+  assert_equal "${output}" "v4.9.1"
 }
 
 @test "n=1 nvh lsr Argon # case" {
-  NVH_MAX_REMOTE_MATCHES=1 run nvh lsr Argon
-  [ "${status}" -eq "0" ]
-  [ "${output}" = "v4.9.1" ]
+  local output=$(NVH_MAX_REMOTE_MATCHES=1 nvh lsr Argon)
+  assert_equal "${output}" "v4.9.1"
 }
 
 
 # numeric versions
 
 @test "n=1 nvh lsr 4" {
-  NVH_MAX_REMOTE_MATCHES=1 run nvh lsr 4
-  [ "${status}" -eq "0" ]
-  [ "${output}" = "v4.9.1" ]
+  local output=$(NVH_MAX_REMOTE_MATCHES=1 nvh lsr 4)
+  assert_equal "${output}" "v4.9.1"
 }
 
 @test "n=1 nvh lsr v4" {
-  NVH_MAX_REMOTE_MATCHES=1 run nvh lsr v4
-  [ "${status}" -eq "0" ]
-  [ "${output}" = "v4.9.1" ]
+  local output=$(NVH_MAX_REMOTE_MATCHES=1 nvh lsr v4)
+  assert_equal "${output}" "v4.9.1"
 }
 
 @test "n=1 nvh lsr 4.9" {
-  NVH_MAX_REMOTE_MATCHES=1 run nvh lsr 4.9
-  [ "${status}" -eq "0" ]
-  [ "${output}" = "v4.9.1" ]
+  local output=$(NVH_MAX_REMOTE_MATCHES=1 nvh lsr 4.9)
+  assert_equal "${output}" "v4.9.1"
 }
 
 @test "n=1 nvh lsr 4.9.1" {
-  NVH_MAX_REMOTE_MATCHES=1 run nvh lsr 4.9.1
-  [ "${status}" -eq "0" ]
-  [ "${output}" = "v4.9.1" ]
+  local output=$(NVH_MAX_REMOTE_MATCHES=1 nvh lsr 4.9.1)
+  assert_equal "${output}" "v4.9.1"
 }
 
 @test "n=1 nvh lsr v4.9.1" {
-  NVH_MAX_REMOTE_MATCHES=1 run nvh lsr v4.9.1
-  [ "${status}" -eq "0" ]
-  [ "${output}" = "v4.9.1" ]
+  local output=$(NVH_MAX_REMOTE_MATCHES=1 nvh lsr v4.9.1)
+  assert_equal "${output}" "v4.9.1"
 }
 
 @test "nvh lsr 6.2 # multiple matches with header" {
-  run nvh lsr 6.2
-  [ "${status}" -eq "0" ]
-  [ "${lines[0]}" = "Listing remote... Displaying 20 matches (use --all to see all)." ]
-  [ "${lines[1]}" = "v6.2.2" ]
-  [ "${lines[2]}" = "v6.2.1" ]
-  [ "${lines[3]}" = "v6.2.0" ]
-  [ "${lines[4]}" = "" ]
+  local output=$(nvh lsr 6.2)
+  assert_equal "${output}" "Listing remote... Displaying 20 matches (use --all to see all).
+v6.2.2
+v6.2.1
+v6.2.0"
 }
 
 @test "n=1 nvh lsr --all 6.2 # --all, multiple matches with no header" {
-  NVH_MAX_REMOTE_MATCHES=1 run nvh lsr --all 6.2
-  [ "${status}" -eq "0" ]
-  [ "${lines[0]}" = "v6.2.2" ]
-  [ "${lines[1]}" = "v6.2.1" ]
-  [ "${lines[2]}" = "v6.2.0" ]
-  [ "${lines[3]}" = "" ]
+  local output=$(NVH_MAX_REMOTE_MATCHES=1 nvh lsr --all 6.2)
+  assert_equal "${output}" "v6.2.2
+v6.2.1
+v6.2.0"
 }
 
 # Checking does not match 8.11
 @test "n=1 nvh lsr v8.1 # numeric match" {
-  NVH_MAX_REMOTE_MATCHES=1 run nvh lsr v8.1
-  [ "${status}" -eq "0" ]
-  [ "${output}" = "v8.1.4" ]
+  local output=$(NVH_MAX_REMOTE_MATCHES=1 nvh lsr v8.1)
+  assert_equal "${output}" "v8.1.4"
 }
 
 
 # Nightly
 
 @test "n=1 nvh lsr nightly" {
-  NVH_MAX_REMOTE_MATCHES=1 run nvh lsr nightly
-  [ "${status}" -eq "0" ]
-  [ "${output}" = "$(display_remote_version nightly)" ]
+  local output=$(NVH_MAX_REMOTE_MATCHES=1 nvh lsr nightly)
+  assert_equal "${output}" "$(display_remote_version nightly)"
 }
 
 @test "n=1 nvh lsr nightly/" {
-  NVH_MAX_REMOTE_MATCHES=1 run nvh lsr nightly/
-  [ "${status}" -eq "0" ]
-  [ "${output}" = "$(display_remote_version nightly)" ]
+  local output=$(NVH_MAX_REMOTE_MATCHES=1 nvh lsr nightly/)
+  assert_equal "${output}" "$(display_remote_version nightly)"
 }
 
 @test "n=1 nvh lsr nightly/latest" {
-  NVH_MAX_REMOTE_MATCHES=1 run nvh lsr nightly/latest
-  [ "${status}" -eq "0" ]
-  [ "${output}" = "$(display_remote_version nightly)" ]
+  local output=$(NVH_MAX_REMOTE_MATCHES=1 nvh lsr nightly/latest)
+  assert_equal "${output}" "$(display_remote_version nightly)"
 }
 
 @test "n=1 nvh lsr nightly/v10.8.1-nightly201808 # partial match" {
-  NVH_MAX_REMOTE_MATCHES=1 run nvh lsr nightly/v10.8.1-nightly201808
-  [ "${status}" -eq "0" ]
-  [ "${output}" = "v10.8.1-nightly2018081382830a809b" ]
+  local output=$(NVH_MAX_REMOTE_MATCHES=1 nvh lsr nightly/v10.8.1-nightly201808)
+  assert_equal "${output}" "v10.8.1-nightly2018081382830a809b"
 }
 
 # Numeric match should not find v7.10.1-nightly2017050369a8053e8a
 @test "n=1 nvh lsr nightly/7.1 # numeric match" {
-  NVH_MAX_REMOTE_MATCHES=1 run nvh lsr nightly/7.1
-  [ "${status}" -eq "0" ]
-  [ "${output}" = "v7.1.1-nightly201611093daf11635d" ]
+  local output=$(NVH_MAX_REMOTE_MATCHES=1 nvh lsr nightly/7.1)
+  assert_equal "${output}" "v7.1.1-nightly201611093daf11635d"
 }
 
 # Numeric match should not find v7.10.1-nightly2017050369a8053e8a
 @test "n=1 nvh lsr nightly/v7.1 # numeric match" {
-  NVH_MAX_REMOTE_MATCHES=1 run nvh lsr nightly/v7.1
-  [ "${status}" -eq "0" ]
-  [ "${output}" = "v7.1.1-nightly201611093daf11635d" ]
+  local output=$(NVH_MAX_REMOTE_MATCHES=1 nvh lsr nightly/v7.1)
+  assert_equal "${output}" "v7.1.1-nightly201611093daf11635d"
 }
 
 @test "nvh lsr nightly/v6.10.3-nightly2017040479546c0b5a # exact" {
-  NVH_MAX_REMOTE_MATCHES=1 run nvh lsr nightly/v6.10.3-nightly2017040479546c0b5a
-  [ "${status}" -eq "0" ]
-  [ "${output}" = "v6.10.3-nightly2017040479546c0b5a" ]
+  local output=$(NVH_MAX_REMOTE_MATCHES=1 nvh lsr nightly/v6.10.3-nightly2017040479546c0b5a)
+  assert_equal "${output}" "v6.10.3-nightly2017040479546c0b5a"
 }

--- a/test/tests/run-which.bats
+++ b/test/tests/run-which.bats
@@ -4,24 +4,18 @@ load shared-functions
 load '../../node_modules/bats-support/load'
 load '../../node_modules/bats-assert/load'
 
-function setup() {
+function setup_file() {
   unset_nvh_env
   # fixed directory so can reuse the two installs
   export NVH_PREFIX="${TMPDIR:-/tmp}/nvh/test/run-which"
-  # beforeAll
-  # See https://github.com/bats-core/bats-core/issues/39
-  if [[ "${BATS_TEST_NUMBER}" -eq 1 ]] ; then
-    # Using --preserve to speed install, as only care about the cached versions.
-    nvh install --preserve 4.9.1
-    nvh install --preserve lts
-  fi
+
+  # Using --preserve to speed install, as only care about the cached versions.
+  nvh install --preserve 4.9.1
+  nvh install --preserve lts
 }
 
-function teardown() {
-  # afterAll
-  if [[ "${#BATS_TEST_NAMES[@]}" -eq "${BATS_TEST_NUMBER}" ]] ; then
-    rm -rf "${NVH_PREFIX}"
-  fi
+function teardown_file() {
+  rm -rf "${NVH_PREFIX}"
 }
 
 

--- a/test/tests/run-which.bats
+++ b/test/tests/run-which.bats
@@ -1,6 +1,8 @@
 #!/usr/bin/env bats
 
 load shared-functions
+load '../../node_modules/bats-support/load'
+load '../../node_modules/bats-assert/load'
 
 function setup() {
   unset_nvh_env
@@ -32,70 +34,61 @@ function teardown() {
 # nvh which
 
 @test "nvh which 4" {
-  run nvh which 4
-  [ "$status" -eq 0 ]
-  [ "$output" = "${NVH_PREFIX}/nvh/versions/node/v4.9.1/bin/node" ]
+  local output=$(nvh which 4)
+  assert_equal "$output" "${NVH_PREFIX}/nvh/versions/node/v4.9.1/bin/node"
 }
 
 
 @test "nvh which v4.9.1" {
-  run nvh which v4.9.1
-  [ "$status" -eq 0 ]
-  [ "$output" = "${NVH_PREFIX}/nvh/versions/node/v4.9.1/bin/node" ]
+  local output=$(nvh which v4.9.1)
+  assert_equal "$output" "${NVH_PREFIX}/nvh/versions/node/v4.9.1/bin/node"
 }
 
 
 @test "nvh which argon" {
-  run nvh which argon
-  [ "$status" -eq 0 ]
-  [ "$output" = "${NVH_PREFIX}/nvh/versions/node/v4.9.1/bin/node" ]
+  local output=$(nvh which argon)
+  assert_equal "$output" "${NVH_PREFIX}/nvh/versions/node/v4.9.1/bin/node"
 }
 
 
 @test "nvh which lts" {
-  run nvh which lts
+  local output=$(nvh which lts)
   local LTS_VERSION="$(display_remote_version lts)"
-  [ "$status" -eq 0 ]
-  [ "$output" = "${NVH_PREFIX}/nvh/versions/node/${LTS_VERSION}/bin/node" ]
+  assert_equal "$output" "${NVH_PREFIX}/nvh/versions/node/${LTS_VERSION}/bin/node"
 }
 
 
 # nvh run
 
 @test "nvh run 4" {
-  run nvh run 4 --version
-  [ "$status" -eq 0 ]
-  [ "$output" = "v4.9.1" ]
+  local output=$(nvh run 4 --version)
+  assert_equal "$output" "v4.9.1"
 }
 
 
 @test "nvh run lts" {
-  run nvh run lts --version
+  local output=$(nvh run lts --version)
   local LTS_VERSION="$(display_remote_version lts)"
-  [ "$status" -eq 0 ]
-  [ "$output" = "${LTS_VERSION}" ]
+  assert_equal "$output" "${LTS_VERSION}"
 }
 
 
 # nvh exec
 
 @test "nvh exec v4.9.1 node" {
-  run nvh exec v4.9.1 node --version
-  [ "$status" -eq 0 ]
-  [ "$output" = "v4.9.1" ]
+  local output=$(nvh exec v4.9.1 node --version)
+  assert_equal "$output" "v4.9.1"
 }
 
 
 @test "nvh exec 4 npm" {
-  run nvh exec 4 npm --version
-  [ "$status" -eq 0 ]
-  [ "$output" = "2.15.11" ]
+  local output=$(nvh exec 4 npm --version)
+  assert_equal "$output" "2.15.11"
 }
 
 
 @test "nvh exec lts" {
-  run nvh exec lts node --version
+  local output=$(nvh exec lts node --version)
   local LTS_VERSION="$(display_remote_version lts)"
-  [ "$status" -eq 0 ]
-  [ "$output" = "${LTS_VERSION}" ]
+  assert_equal "$output" "${LTS_VERSION}"
 }

--- a/test/tests/version-auto-priority.bats
+++ b/test/tests/version-auto-priority.bats
@@ -1,6 +1,8 @@
 #!/usr/bin/env bats
 
 load shared-functions
+load '../../node_modules/bats-support/load'
+load '../../node_modules/bats-assert/load'
 
 
 # auto
@@ -14,8 +16,6 @@ function setup() {
   rm -f "${MY_DIR}/.nvh-node-version"
   rm -f "${MY_DIR}/.node-version"
   rm -f "${MY_DIR}/.nvmrc"
-
-  PAYLOAD_LINE=2
 
   # Need a version of node available for reading package.json
   export NVH_PREFIX="${MY_DIR}"
@@ -41,8 +41,7 @@ function teardown() {
   echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
 
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "v401.0.1" ]
+  assert_line "v401.0.1"
 }
 
 @test ".node-version second" {
@@ -52,8 +51,7 @@ function teardown() {
   echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
 
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "v401.0.2" ]
+  assert_line "v401.0.2"
 }
 
 @test ".nvmrc third" {
@@ -62,8 +60,7 @@ function teardown() {
   echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
 
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "v401.0.3" ]
+  assert_line "v401.0.3"
 }
 
 @test ".package.json last" {
@@ -71,7 +68,6 @@ function teardown() {
   echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
 
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "v401.0.4" ]
+  assert_line "v401.0.4"
 }
 

--- a/test/tests/version-auto-priority.bats
+++ b/test/tests/version-auto-priority.bats
@@ -37,8 +37,8 @@ function teardown_file() {
   echo "401.0.3" > .nvmrc
   echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
 
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v401.0.1"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v401.0.1"
 }
 
 @test ".node-version second" {
@@ -47,8 +47,8 @@ function teardown_file() {
   echo "401.0.3" > .nvmrc
   echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
 
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v401.0.2"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v401.0.2"
 }
 
 @test ".nvmrc third" {
@@ -56,15 +56,15 @@ function teardown_file() {
   echo "401.0.3" > .nvmrc
   echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
 
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v401.0.3"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v401.0.3"
 }
 
 @test ".package.json last" {
   cd "${MY_DIR}"
   echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
 
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v401.0.4"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v401.0.4"
 }
 

--- a/test/tests/version-auto-priority.bats
+++ b/test/tests/version-auto-priority.bats
@@ -7,30 +7,27 @@ load '../../node_modules/bats-assert/load'
 
 # auto
 
-function setup() {
+function setup_file() {
   unset_nvh_env
   tmpdir="${TMPDIR:-/tmp}"
   export MY_DIR="${tmpdir}/nvh/test/version-resolve-auto-priority"
   mkdir -p "${MY_DIR}"
-  rm -f "${MY_DIR}/package.json"
-  rm -f "${MY_DIR}/.nvh-node-version"
-  rm -f "${MY_DIR}/.node-version"
-  rm -f "${MY_DIR}/.nvmrc"
 
   # Need a version of node available for reading package.json
   export NVH_PREFIX="${MY_DIR}"
   export PATH="${MY_DIR}/bin:${PATH}"
-  if [[ "${BATS_TEST_NUMBER}" -eq 1 ]] ; then
-    # beforeAll
-    nvh install lts
-  fi
+  nvh install lts
 }
 
-function teardown() {
-  # afterAll
-  if [[ "${#BATS_TEST_NAMES[@]}" -eq "${BATS_TEST_NUMBER}" ]] ; then
-    rm -rf "${MY_DIR}"
-  fi
+function setup() {
+  rm -f "${MY_DIR}/package.json"
+  rm -f "${MY_DIR}/.nvh-node-version"
+  rm -f "${MY_DIR}/.node-version"
+  rm -f "${MY_DIR}/.nvmrc"
+}
+
+function teardown_file() {
+  rm -rf "${MY_DIR}"
 }
 
 @test ".nvh-node-version first" {

--- a/test/tests/version-resolve-auto-engine.bats
+++ b/test/tests/version-resolve-auto-engine.bats
@@ -1,6 +1,8 @@
 #!/usr/bin/env bats
 
 load shared-functions
+load '../../node_modules/bats-support/load'
+load '../../node_modules/bats-assert/load'
 
 
 # auto
@@ -24,16 +26,12 @@ function setup() {
   ##        found : package.json
   ##         read : 101.0.1
   ## v101.0.1
-  # so version payload is...
-  PAYLOAD_SIMPLE_LINE=2
 
   # Output looks likes:
   ##        found : package.json
   ##       read : 4.8.2 - 4.8.4
   ##  resolving : 4.8.2 - 4.8.4
   ## v4.8.4
-  # so version payload is...
-  PAYLOAD_COMPLEX_LINE=3
 }
 
 function teardown() {
@@ -55,32 +53,28 @@ function write_engine() {
   cd "${MY_DIR}"
   write_engine "103.0.1"
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "v103.0.1" ]
+  assert_line "v103.0.1"
 }
 
 @test "auto engine, v104.0.2" {
   cd "${MY_DIR}"
   write_engine "v104.0.2"
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "v104.0.2" ]
+  assert_line "v104.0.2"
 }
 
 @test "auto engine, =104.0.3" {
   cd "${MY_DIR}"
   write_engine "=103.0.3"
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "v103.0.3" ]
+  assert_line "v103.0.3"
 }
 
 @test "auto engine, =v104.0.4" {
   cd "${MY_DIR}"
   write_engine "=v104.0.4"
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "v104.0.4" ]
+  assert_line "v104.0.4"
 }
 
 @test "auto engine, >1" {
@@ -88,8 +82,7 @@ function write_engine() {
   cd "${MY_DIR}"
   write_engine ">1"
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "${TARGET_VERSION}" ]
+  assert_line "${TARGET_VERSION}"
 }
 
 @test "auto engine, >=2" {
@@ -97,80 +90,70 @@ function write_engine() {
   cd "${MY_DIR}"
   write_engine ">=2"
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "${TARGET_VERSION}" ]
+  assert_line "${TARGET_VERSION}"
 }
 
 @test "auto engine, 8" {
   cd "${MY_DIR}"
   write_engine "8"
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "v8.17.0" ]
+  assert_line "v8.17.0"
 }
 
 @test "auto engine, 8.x" {
   cd "${MY_DIR}"
   write_engine "8.x"
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "v8.17.0" ]
+  assert_line "v8.17.0"
 }
 
 @test "auto engine, 8.X" {
   cd "${MY_DIR}"
   write_engine "8.X"
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "v8.17.0" ]
+  assert_line "v8.17.0"
 }
 
 @test "auto engine, 8.*" {
   cd "${MY_DIR}"
   write_engine "8.*"
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "v8.17.0" ]
+  assert_line "v8.17.0"
 }
 
 @test "auto engine, ~8.11.0" {
   cd "${MY_DIR}"
   write_engine "~8.11.0"
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "v8.11.4" ]
+  assert_line "v8.11.4"
 }
 
 @test "auto engine, ~8.11" {
   cd "${MY_DIR}"
   write_engine "~8.11"
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "v8.11.4" ]
+  assert_line "v8.11.4"
 }
 
 @test "auto engine, ~8" {
   cd "${MY_DIR}"
   write_engine "~8"
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "v8.17.0" ]
+  assert_line "v8.17.0"
 }
 
 @test "auto engine, ^8.11.0" {
   cd "${MY_DIR}"
   write_engine "^8.11.0"
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "v8.17.0" ]
+  assert_line "v8.17.0"
 }
 
 @test "auto engine, ^8.x" {
   cd "${MY_DIR}"
   write_engine "^8.x"
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "v8.17.0" ]
+  assert_line "v8.17.0"
 }
 
 @test "auto engine, subdir" {
@@ -179,30 +162,26 @@ function write_engine() {
   mkdir -p sub-engine
   cd sub-engine
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "v8.11.2" ]
+  assert_line "v8.11.2"
 }
 
 @test "auto engine (semver), <8.12" {
   cd "${MY_DIR}"
   write_engine "<8.12"
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_COMPLEX_LINE}]}" = "v8.11.4" ]
+  assert_line "v8.11.4"
 }
 
 @test "auto engine (semver), 8.11.1 - 8.11.3" {
   cd "${MY_DIR}"
   write_engine "8.11.1 - 8.11.3"
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_COMPLEX_LINE}]}" = "v8.11.3" ]
+  assert_line "v8.11.3"
 }
 
 @test "auto engine (semver), >8.1 <8.12 || >2.1 <3.4" {
   cd "${MY_DIR}"
   write_engine ">8.1 <8.12 || >2.1 <3.4"
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_COMPLEX_LINE}]}" = "v8.11.4" ]
+  assert_line "v8.11.4"
 }

--- a/test/tests/version-resolve-auto-engine.bats
+++ b/test/tests/version-resolve-auto-engine.bats
@@ -7,20 +7,16 @@ load '../../node_modules/bats-assert/load'
 
 # auto
 
-function setup() {
+function setup_file() {
   unset_nvh_env
   tmpdir="${TMPDIR:-/tmp}"
   export MY_DIR="${tmpdir}/nvh/test/version-resolve-auto-engine"
   mkdir -p "${MY_DIR}"
-  rm -f "${MY_DIR}/package.json"
 
   # Need a version of node and npx available for reading package.json
   export NVH_PREFIX="${MY_DIR}"
   export PATH="${MY_DIR}/bin:${PATH}"
-  # beforeAll
-  if [[ "${BATS_TEST_NUMBER}" -eq 1 ]] ; then
-    nvh install lts
-  fi
+  nvh install lts
 
   # Output looks likes:
   ##        found : package.json
@@ -34,11 +30,12 @@ function setup() {
   ## v4.8.4
 }
 
-function teardown() {
-  # afterAll
-  if [[ "${#BATS_TEST_NAMES[@]}" -eq "${BATS_TEST_NUMBER}" ]] ; then
-    rm -rf "${MY_DIR}"
-  fi
+function setup() {
+  rm -f "${MY_DIR}/package.json"
+}
+
+function teardown_file() {
+  rm -rf "${MY_DIR}"
 }
 
 function write_engine() {

--- a/test/tests/version-resolve-auto-engine.bats
+++ b/test/tests/version-resolve-auto-engine.bats
@@ -49,108 +49,108 @@ function write_engine() {
 @test "auto engine, 104.0.1" {
   cd "${MY_DIR}"
   write_engine "103.0.1"
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v103.0.1"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v103.0.1"
 }
 
 @test "auto engine, v104.0.2" {
   cd "${MY_DIR}"
   write_engine "v104.0.2"
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v104.0.2"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v104.0.2"
 }
 
 @test "auto engine, =104.0.3" {
   cd "${MY_DIR}"
   write_engine "=103.0.3"
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v103.0.3"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v103.0.3"
 }
 
 @test "auto engine, =v104.0.4" {
   cd "${MY_DIR}"
   write_engine "=v104.0.4"
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v104.0.4"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v104.0.4"
 }
 
 @test "auto engine, >1" {
   local TARGET_VERSION="$(display_remote_version latest)"
   cd "${MY_DIR}"
   write_engine ">1"
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "${TARGET_VERSION}"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "${TARGET_VERSION}"
 }
 
 @test "auto engine, >=2" {
   local TARGET_VERSION="$(display_remote_version latest)"
   cd "${MY_DIR}"
   write_engine ">=2"
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "${TARGET_VERSION}"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "${TARGET_VERSION}"
 }
 
 @test "auto engine, 8" {
   cd "${MY_DIR}"
   write_engine "8"
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v8.17.0"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v8.17.0"
 }
 
 @test "auto engine, 8.x" {
   cd "${MY_DIR}"
   write_engine "8.x"
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v8.17.0"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v8.17.0"
 }
 
 @test "auto engine, 8.X" {
   cd "${MY_DIR}"
   write_engine "8.X"
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v8.17.0"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v8.17.0"
 }
 
 @test "auto engine, 8.*" {
   cd "${MY_DIR}"
   write_engine "8.*"
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v8.17.0"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v8.17.0"
 }
 
 @test "auto engine, ~8.11.0" {
   cd "${MY_DIR}"
   write_engine "~8.11.0"
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v8.11.4"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v8.11.4"
 }
 
 @test "auto engine, ~8.11" {
   cd "${MY_DIR}"
   write_engine "~8.11"
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v8.11.4"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v8.11.4"
 }
 
 @test "auto engine, ~8" {
   cd "${MY_DIR}"
   write_engine "~8"
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v8.17.0"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v8.17.0"
 }
 
 @test "auto engine, ^8.11.0" {
   cd "${MY_DIR}"
   write_engine "^8.11.0"
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v8.17.0"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v8.17.0"
 }
 
 @test "auto engine, ^8.x" {
   cd "${MY_DIR}"
   write_engine "^8.x"
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v8.17.0"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v8.17.0"
 }
 
 @test "auto engine, subdir" {
@@ -158,27 +158,27 @@ function write_engine() {
   write_engine "8.11.2"
   mkdir -p sub-engine
   cd sub-engine
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v8.11.2"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v8.11.2"
 }
 
 @test "auto engine (semver), <8.12" {
   cd "${MY_DIR}"
   write_engine "<8.12"
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v8.11.4"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v8.11.4"
 }
 
 @test "auto engine (semver), 8.11.1 - 8.11.3" {
   cd "${MY_DIR}"
   write_engine "8.11.1 - 8.11.3"
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v8.11.3"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v8.11.3"
 }
 
 @test "auto engine (semver), >8.1 <8.12 || >2.1 <3.4" {
   cd "${MY_DIR}"
   write_engine ">8.1 <8.12 || >2.1 <3.4"
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v8.11.4"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v8.11.4"
 }

--- a/test/tests/version-resolve-auto-file.bats
+++ b/test/tests/version-resolve-auto-file.bats
@@ -4,6 +4,8 @@
 # Not testing all the permutations on both files, as know they are currenly implemented using same code!
 
 load shared-functions
+load '../../node_modules/bats-support/load'
+load '../../node_modules/bats-assert/load'
 
 
 # auto
@@ -20,8 +22,6 @@ function setup() {
   ##        found : .nvh-node-version
   ##         read : 101.0.1
   ## v101.0.1
-  # so payload to check is on line #2.
-  PAYLOAD_LINE=2
 }
 
 function teardown() {
@@ -41,40 +41,35 @@ function teardown() {
   cd "${MY_DIR}"
   printf "101.0.1" > .nvh-node-version
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "v101.0.1" ]
+  assert_line "v101.0.1"
 }
 
 @test "auto .nvh-node-version, unix eol" {
   cd "${MY_DIR}"
   printf "101.0.2\n" > .nvh-node-version
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "v101.0.2" ]
+  assert_line "v101.0.2"
 }
 
 @test "auto .nvh-node-version, Windows eol" {
   cd "${MY_DIR}"
   printf "101.0.3\r\n" > .nvh-node-version
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "v101.0.3" ]
+  assert_line "v101.0.3"
 }
 
 @test "auto .nvh-node-version, leading v" {
   cd "${MY_DIR}"
   printf "v101.0.4\n" > .nvh-node-version
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "v101.0.4" ]
+  assert_line "v101.0.4"
 }
 
 @test "auto .nvh-node-version, first line only" {
   cd "${MY_DIR}"
   printf "101.0.5\nmore text\n" > .nvh-node-version
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "v101.0.5" ]
+  assert_line "v101.0.5"
 }
 
 @test "auto .nvh-node-version, from sub directory" {
@@ -83,8 +78,7 @@ function teardown() {
   mkdir -p sub6
   cd sub6
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "v101.0.6" ]
+  assert_line "v101.0.6"
 }
 
 @test "auto .node-version, partial version lookup" {
@@ -92,8 +86,7 @@ function teardown() {
   cd "${MY_DIR}"
   printf "4.9\n" > .node-version
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "v4.9.1" ]
+  assert_line "v4.9.1"
 }
 
 @test "auto .node-version, from sub directory" {
@@ -102,7 +95,6 @@ function teardown() {
   mkdir -p sub7
   cd sub7
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "v101.0.7" ]
+  assert_line "v101.0.7"
 }
 

--- a/test/tests/version-resolve-auto-file.bats
+++ b/test/tests/version-resolve-auto-file.bats
@@ -10,13 +10,11 @@ load '../../node_modules/bats-assert/load'
 
 # auto
 
-function setup() {
+function setup_file() {
   unset_nvh_env
   tmpdir="${TMPDIR:-/tmp}"
   export MY_DIR="${tmpdir}/nvh/test/version-resolve-auto-file"
   mkdir -p "${MY_DIR}"
-  rm -f "${MY_DIR}/.nvh-node-version"
-  rm -f "${MY_DIR}/.node-version"
 
   # Output looks likes:
   ##        found : .nvh-node-version
@@ -24,11 +22,13 @@ function setup() {
   ## v101.0.1
 }
 
-function teardown() {
-  # afterAll
-  if [[ "${#BATS_TEST_NAMES[@]}" -eq "${BATS_TEST_NUMBER}" ]] ; then
-    rm -rf "${MY_DIR}"
-  fi
+function setup() {
+  rm -f "${MY_DIR}/.nvh-node-version"
+  rm -f "${MY_DIR}/.node-version"
+}
+
+function teardown_file() {
+  rm -rf "${MY_DIR}"
 }
 
 @test "auto, missing file" {

--- a/test/tests/version-resolve-auto-file.bats
+++ b/test/tests/version-resolve-auto-file.bats
@@ -40,36 +40,36 @@ function teardown_file() {
 @test "auto .nvh-node-version, no eol" {
   cd "${MY_DIR}"
   printf "101.0.1" > .nvh-node-version
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v101.0.1"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v101.0.1"
 }
 
 @test "auto .nvh-node-version, unix eol" {
   cd "${MY_DIR}"
   printf "101.0.2\n" > .nvh-node-version
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v101.0.2"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v101.0.2"
 }
 
 @test "auto .nvh-node-version, Windows eol" {
   cd "${MY_DIR}"
   printf "101.0.3\r\n" > .nvh-node-version
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v101.0.3"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v101.0.3"
 }
 
 @test "auto .nvh-node-version, leading v" {
   cd "${MY_DIR}"
   printf "v101.0.4\n" > .nvh-node-version
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v101.0.4"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v101.0.4"
 }
 
 @test "auto .nvh-node-version, first line only" {
   cd "${MY_DIR}"
   printf "101.0.5\nmore text\n" > .nvh-node-version
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v101.0.5"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v101.0.5"
 }
 
 @test "auto .nvh-node-version, from sub directory" {
@@ -77,16 +77,16 @@ function teardown_file() {
   printf "101.0.6\nmore text\n" > .nvh-node-version
   mkdir -p sub6
   cd sub6
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v101.0.6"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v101.0.6"
 }
 
 @test "auto .node-version, partial version lookup" {
   # Check normal resolving
   cd "${MY_DIR}"
   printf "4.9\n" > .node-version
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v4.9.1"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v4.9.1"
 }
 
 @test "auto .node-version, from sub directory" {
@@ -94,7 +94,7 @@ function teardown_file() {
   printf "101.0.7\nmore text\n" > .nvh-node-version
   mkdir -p sub7
   cd sub7
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v101.0.7"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v101.0.7"
 }
 

--- a/test/tests/version-resolve-auto-nvmrc.bats
+++ b/test/tests/version-resolve-auto-nvmrc.bats
@@ -32,39 +32,39 @@ function teardown_file() {
 @test "auto .nvmrc, numeric" {
   cd "${MY_DIR}"
   printf "102.0.1\n" > .nvmrc
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v102.0.1"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v102.0.1"
 }
 
 @test "auto .nvmrc, numeric with leading v" {
   cd "${MY_DIR}"
   printf "v102.0.2\n" > .nvmrc
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v102.0.2"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v102.0.2"
 }
 
 @test "auto .nvmrc, node" {
   local TARGET_VERSION="$(display_remote_version latest)"
   cd "${MY_DIR}"
   printf "node\n" > .nvmrc
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "${TARGET_VERSION}"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "${TARGET_VERSION}"
 }
 
 @test "auto .nvmrc, lts/*" {
   local TARGET_VERSION="$(display_remote_version lts)"
   cd "${MY_DIR}"
   printf "lts/*\n" > .nvmrc
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "${TARGET_VERSION}"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "${TARGET_VERSION}"
 }
 
 @test "auto .nvmrc, lts/argon" {
   local TARGET_VERSION="$(display_remote_version lts)"
   cd "${MY_DIR}"
   printf "lts/argon\n" > .nvmrc
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v4.9.1"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v4.9.1"
 }
 
 @test "auto .nvmrc, sub directory" {
@@ -72,6 +72,6 @@ function teardown_file() {
   printf "v102.0.3\n" > .nvmrc
   mkdir -p sub-npmrc
   cd sub-npmrc
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  assert_line "v102.0.3"
+  output="$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "v102.0.3"
 }

--- a/test/tests/version-resolve-auto-nvmrc.bats
+++ b/test/tests/version-resolve-auto-nvmrc.bats
@@ -9,12 +9,11 @@ load '../../node_modules/bats-assert/load'
 
 # auto
 
-function setup() {
+function setup_file() {
   unset_nvh_env
   tmpdir="${TMPDIR:-/tmp}"
   export MY_DIR="${tmpdir}/nvh/test/version-resolve-auto-nvmrc"
   mkdir -p "${MY_DIR}"
-  rm -f "${MY_DIR}/.nvmrc"
 
   # Output looks likes:
   ##        found : .nvmrc
@@ -22,11 +21,12 @@ function setup() {
   ## v101.0.1
 }
 
-function teardown() {
-  # afterAll
-  if [[ "${#BATS_TEST_NAMES[@]}" -eq "${BATS_TEST_NUMBER}" ]] ; then
-    rm -rf "${MY_DIR}"
-  fi
+function setup() {
+  rm -f "${MY_DIR}/.nvmrc"
+}
+
+function teardown_file() {
+  rm -rf "${MY_DIR}"
 }
 
 @test "auto .nvmrc, numeric" {

--- a/test/tests/version-resolve-auto-nvmrc.bats
+++ b/test/tests/version-resolve-auto-nvmrc.bats
@@ -3,6 +3,8 @@
 # Note: full semver is resolved without lookup, so can use arbitrary versions for testing like 999.999.999
 
 load shared-functions
+load '../../node_modules/bats-support/load'
+load '../../node_modules/bats-assert/load'
 
 
 # auto
@@ -18,8 +20,6 @@ function setup() {
   ##        found : .nvmrc
   ##         read : 101.0.1
   ## v101.0.1
-  # so payload to check is on line #2.
-  PAYLOAD_LINE=2
 }
 
 function teardown() {
@@ -33,16 +33,14 @@ function teardown() {
   cd "${MY_DIR}"
   printf "102.0.1\n" > .nvmrc
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "v102.0.1" ]
+  assert_line "v102.0.1"
 }
 
 @test "auto .nvmrc, numeric with leading v" {
   cd "${MY_DIR}"
   printf "v102.0.2\n" > .nvmrc
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "v102.0.2" ]
+  assert_line "v102.0.2"
 }
 
 @test "auto .nvmrc, node" {
@@ -50,8 +48,7 @@ function teardown() {
   cd "${MY_DIR}"
   printf "node\n" > .nvmrc
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "${TARGET_VERSION}" ]
+  assert_line "${TARGET_VERSION}"
 }
 
 @test "auto .nvmrc, lts/*" {
@@ -59,8 +56,7 @@ function teardown() {
   cd "${MY_DIR}"
   printf "lts/*\n" > .nvmrc
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "${TARGET_VERSION}" ]
+  assert_line "${TARGET_VERSION}"
 }
 
 @test "auto .nvmrc, lts/argon" {
@@ -68,8 +64,7 @@ function teardown() {
   cd "${MY_DIR}"
   printf "lts/argon\n" > .nvmrc
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "v4.9.1" ]
+  assert_line "v4.9.1"
 }
 
 @test "auto .nvmrc, sub directory" {
@@ -78,6 +73,5 @@ function teardown() {
   mkdir -p sub-npmrc
   cd sub-npmrc
   run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "v102.0.3" ]
+  assert_line "v102.0.3"
 }

--- a/test/tests/version-resolve.bats
+++ b/test/tests/version-resolve.bats
@@ -3,6 +3,8 @@
 # Note: full semver is resolved without lookup, so can use arbitrary versions for testing like 999.999.999
 
 load shared-functions
+load '../../node_modules/bats-support/load'
+load '../../node_modules/bats-assert/load'
 
 function setup() {
   unset_nvh_env
@@ -13,42 +15,36 @@ function setup() {
 
 @test "display_latest_resolved_version active" {
   local TARGET_VERSION="$(display_remote_version latest)"
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION active
-  [ "$status" -eq 0 ]
-  [ "$output" = "${TARGET_VERSION}" ]
+  local output=$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION active)
+  assert_equal "$output" "${TARGET_VERSION}"
 }
 
 @test "display_latest_resolved_version lts_active" {
   local TARGET_VERSION="$(display_remote_version lts)"
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION lts_active
-  [ "$status" -eq 0 ]
-  [ "$output" = "${TARGET_VERSION}" ]
+  local output=$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION lts_active)
+  assert_equal "$output" "${TARGET_VERSION}"
 }
 
 @test "display_latest_resolved_version lts_latest" {
   local TARGET_VERSION="$(display_remote_version lts)"
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION lts_latest
-  [ "$status" -eq 0 ]
-  [ "$output" = "${TARGET_VERSION}" ]
+  local output=$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION lts_latest)
+  assert_equal "$output" "${TARGET_VERSION}"
 }
 
 @test "display_latest_resolved_version lts" {
   local TARGET_VERSION="$(display_remote_version lts)"
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION lts
-  [ "$status" -eq 0 ]
-  [ "$output" = "${TARGET_VERSION}" ]
+  local output=$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION lts)
+  assert_equal "$output" "${TARGET_VERSION}"
 }
 
 @test "display_latest_resolved_version current" {
   local TARGET_VERSION="$(display_remote_version latest)"
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION current
-  [ "$status" -eq 0 ]
-  [ "$output" = "${TARGET_VERSION}" ]
+  local output=$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION current)
+  assert_equal "$output" "${TARGET_VERSION}"
 }
 
 @test "display_latest_resolved_version supported" {
   local TARGET_VERSION="$(display_remote_version latest)"
-  run nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION supported
-  [ "$status" -eq 0 ]
-  [ "$output" = "${TARGET_VERSION}" ]
+  local output=$(nvh NVH_TEST_DISPLAY_LATEST_RESOLVED_VERSION supported)
+  assert_equal "$output" "${TARGET_VERSION}"
 }


### PR DESCRIPTION
- upgrade to bats-core 1.2.1
- use new setup_file and teardown_file (rather than check test number)
- add bats-assert for clearer errors when testing versions and output
- avoid anti-pattern using run just to test output